### PR TITLE
Arreglado username duplicado entre alumno y profesor en el registro

### DIFF
--- a/src/main/java/org/springframework/samples/iTeaching/web/AlumnoController.java
+++ b/src/main/java/org/springframework/samples/iTeaching/web/AlumnoController.java
@@ -64,7 +64,7 @@ public class AlumnoController {
 
 	@InitBinder("alumno")
 	public void initVehiculoBinder(WebDataBinder dataBinder) {
-		dataBinder.setValidator(new AlumnoValidator(alumnoService));
+		dataBinder.setValidator(new AlumnoValidator(alumnoService, profesorService));
 	}
 
 	@InitBinder

--- a/src/main/java/org/springframework/samples/iTeaching/web/AlumnoValidator.java
+++ b/src/main/java/org/springframework/samples/iTeaching/web/AlumnoValidator.java
@@ -6,7 +6,9 @@ import java.util.regex.Pattern;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.samples.iTeaching.model.Alumno;
+import org.springframework.samples.iTeaching.model.Profesor;
 import org.springframework.samples.iTeaching.service.AlumnoService;
+import org.springframework.samples.iTeaching.service.ProfesorService;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -19,10 +21,12 @@ public class AlumnoValidator implements Validator {
 
 
 	private AlumnoService aluSer;
+	private ProfesorService profSer;
 	
 	@Autowired
-	public AlumnoValidator(AlumnoService aS) {
+	public AlumnoValidator(AlumnoService aS, ProfesorService pS) {
 		this.aluSer = aS;
+		this.profSer = pS;
 	}
 	public String nombreUsuarioLogeado() {
 		Authentication quePasa = SecurityContextHolder.getContext().getAuthentication();
@@ -73,9 +77,15 @@ public class AlumnoValidator implements Validator {
 		}
 		
 		if(nombreLogeado=="noLogin") {
+			List<Profesor> listaProfesor = profSer.findAll();
 			List<Alumno> listaAlumnos = aluSer.findAll();
 			for(Alumno alumnoIndividual:listaAlumnos) {
 				if(alumno.getUser().getUsername().equals(alumnoIndividual.getUser().getUsername())) {
+					errors.rejectValue("user.username", " El nombre de usuario ya existe", "El nombre de usuario ya existe");
+				}
+			}
+			for(Profesor profesorIndividual:listaProfesor) {
+				if(alumno.getUser().getUsername().equals(profesorIndividual.getUser().getUsername())) {
 					errors.rejectValue("user.username", " El nombre de usuario ya existe", "El nombre de usuario ya existe");
 				}
 			}

--- a/src/main/java/org/springframework/samples/iTeaching/web/ProfesorController.java
+++ b/src/main/java/org/springframework/samples/iTeaching/web/ProfesorController.java
@@ -63,7 +63,7 @@ public class ProfesorController {
 	
 	@InitBinder("profesor")
 	public void initVehiculoBinder(WebDataBinder dataBinder) {
-		dataBinder.setValidator(new ProfesorValidator(profesorService));
+		dataBinder.setValidator(new ProfesorValidator(profesorService, alumnoService));
 	}
 
 	@InitBinder

--- a/src/main/java/org/springframework/samples/iTeaching/web/ProfesorValidator.java
+++ b/src/main/java/org/springframework/samples/iTeaching/web/ProfesorValidator.java
@@ -5,7 +5,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.samples.iTeaching.model.Alumno;
 import org.springframework.samples.iTeaching.model.Profesor;
+import org.springframework.samples.iTeaching.service.AlumnoService;
 import org.springframework.samples.iTeaching.service.ProfesorService;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -17,10 +19,12 @@ import org.springframework.validation.Validator;
 public class ProfesorValidator implements Validator {
 
 private ProfesorService profSer;
+private AlumnoService alumnSer;
 	
 	@Autowired
-	public ProfesorValidator(ProfesorService pS) {
+	public ProfesorValidator(ProfesorService pS, AlumnoService aS) {
 		this.profSer = pS;
+		this.alumnSer = aS;
 	}
 	
 	public String nombreUsuarioLogeado() {
@@ -74,8 +78,14 @@ private ProfesorService profSer;
 		
 		if(nombreLogeado=="noLogin") {
 			List<Profesor> listaProfesor = profSer.findAll();
+			List<Alumno> listaAlumno = alumnSer.findAll();
 			for(Profesor profesorIndividual:listaProfesor) {
 				if(profesor.getUser().getUsername().equals(profesorIndividual.getUser().getUsername())) {
+					errors.rejectValue("user.username", " El nombre de usuario ya existe", "El nombre de usuario ya existe");
+				}
+			}
+			for(Alumno alumnoIndividual : listaAlumno) {
+				if(profesor.getUser().getUsername().equals(alumnoIndividual.getUser().getUsername())) {
 					errors.rejectValue("user.username", " El nombre de usuario ya existe", "El nombre de usuario ya existe");
 				}
 			}


### PR DESCRIPTION
Antes de este fix un profesor podia registrarse con el username de un alumno ya registrado, y viceversa. Esto logicamente derivaba en un error no capturado